### PR TITLE
feat: implement dsl for creating pact matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- feat: implement dsl for creating pact matchers
+
 ## 0.0.1
 
 - Initial version.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # pact_dart
 
+[![ci](https://github.com/matthewshirley/pact_dart/actions/workflows/ci.yml/badge.svg)](https://github.com/matthewshirley/pact_dart/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/matthewshirley/pact_dart/branch/main/graph/badge.svg?token=N7495X6QCL)](https://codecov.io/gh/matthewshirley/pact_dart)
+
 ⚠️ WIP Package - API is not yet confirmed ⚠️
 
 This library provides a Dart DSL for generating Pact contracts. It implements [Pact Specification v3](https://github.com/pact-foundation/pact-specification/tree/version-3) by taking advantage of the pact_ffi library.
+
+### Installation
+
+Simply, install the package using `pub`:
+
+```bash
+dart pub add pact_dart
+```
+
+Currently, the `libpact_ffi` dependency is included for x86_64 macOS, Linux and Windows.
 
 ### Example
 
@@ -27,3 +40,76 @@ expect(jsonDecode(res.body)['name'], equals('Betsy'));
 
 pact.writePactFile(overwrite: true);
 ```
+
+### Matching
+
+`pact_dart` supports request/response (matching techniques)[https://docs.pact.io/getting_started/matching/] as defined in the [Pact Specification v3](https://github.com/pact-foundation/pact-specification/tree/version-3).
+
+```dart
+pact
+    .newInteraction('create an alligator')
+    .uponReceiving('a request to create an alligator named betsy')
+    .withRequest('POST', '/alligator', body: {
+        'alligator': {
+        'name': PactMatchers.EqualTo('Betsy'),
+        'isHungry': PactMatchers.SomethingLike(true),
+        'countOfTeeth': PactMatchers.IntegerLike(80),
+        'countOfHumansScared': PactMatchers.DecimalLike(12.5),
+        'favouriteFood': PactMatchers.Includes('Pineapple'),
+        'status': PactMatchers.Null(),
+        'email': PactMatchers.Term(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$', 'betsy@example.com'),
+        'friends': PactMatchers.EachLike(['Beth'], min: 1, max: 5)
+        }
+    }).willRespondWith(201);
+
+    final uri = Uri.parse('http://localhost:1235/alligator');
+    final res = await http.post(uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+              'alligator': {
+                  'name': 'Betsy',
+                  'isHungry': false,
+                  'countOfTeeth': 78,
+                  'countOfHumansScared': 100.5,
+                  'favouriteFood': ['Pineapple', 'Kibble', 'Human'],
+                  'status': null,
+                  'email': 'betsylovers@example.com',
+                  'friends': ['Beth', 'Susan', 'Graham', 'Michael', 'Chloe']
+                }
+            }
+        )
+    );
+```
+
+### Feature support
+
+| Feature                                                                | Supported |
+| ---------------------------------------------------------------------- | --------- |
+| HTTP Pacts                                                             | 🔨        |
+| Asychronous message pacts                                              | ❌        |
+| Regular expression matching                                            | ✅        |
+| Type based matching ("like")                                           | ✅        |
+| Flexible array length ("each like")                                    | ✅        |
+| Verify a pact that uses the Pact specification v3 format               | ✅        |
+| Pact specification v3 matchers                                         | 🔨        |
+| Pact specification v3 generators                                       | ❌        |
+| Multiple provider states (pact creation)                               | ❌        |
+| Multiple provider states (pact verification)                           | ❌        |
+| Publish pacts to Pact Broker                                           | ❌        |
+| Tag consumer version in Pact Broker when publishing pact               | ❌        |
+| Dynamically fetch pacts for provider from Pact Broker for verification | ❌        |
+| Dynamically fetch pacts for provider with specified tags               | ❌        |
+| Automatically tag consumer/provider with name of git branch            | ❌        |
+| Use 'pacts for verification' Pact Broker API                           | ❌        |
+| Pending pacts                                                          | ❌        |
+| WIP pacts                                                              | ❌        |
+| JSON test results output                                               | ❌        |
+| XML test results output                                                | ❌        |
+| Markdown test results output                                           | ❌        |
+| Run a single interaction when verifying a pact                         | ❌        |
+| Injecting values from provider state callbacks                         | ❌        |
+| Date/Time expressions with generators                                  | ❌        |
+
+- ✅ -- Implemented
+- 🔨 -- Partially implemented
+- ❌ -- Not implemented

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -1,3 +1,12 @@
+class PactMatcherError extends Error {
+  final String reason;
+
+  PactMatcherError(this.reason);
+
+  @override
+  String toString() => 'Unable to create PactMatcher. $reason';
+}
+
 class PactMismatchError extends Error {
   final String mismatches;
 

--- a/lib/src/interaction.dart
+++ b/lib/src/interaction.dart
@@ -36,7 +36,9 @@ class Interaction {
   }
 
   Interaction withRequest(String method, String path,
-      {Map<String, String>? headers, Map<String, String>? query, Map? body}) {
+      {Map<String, String>? headers,
+      Map<String, String>? query,
+      dynamic? body}) {
     if (method.isEmpty || path.isEmpty) {
       throw Error();
     }

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -1,0 +1,89 @@
+import 'package:pact_dart/src/errors.dart';
+
+class PactMatchers {
+  /// Matches that the type and value is equal.
+  static Map EqualTo(dynamic example) {
+    return {'pact:matcher:type': 'equality', 'value': example};
+  }
+
+  static Map Term(String regex, String example) {
+    if (regex.isEmpty || example.isEmpty) {
+      throw PactMatcherError('`regex` and `example` cannot be empty.');
+    }
+
+    final isExampleValid = RegExp(regex).hasMatch(example);
+    if (!isExampleValid) {
+      throw StateError('`example` was not matched by the regex passed.');
+    }
+
+    return {'pact:matcher:type': 'regex', 'regex': regex, 'value': example};
+  }
+
+  /// Matches that the type is equal, and does not care for the value.
+  ///
+  /// For example, "Betsy" is the same type as "Graham"
+  static Map SomethingLike(dynamic example) {
+    if (example is Function) {
+      throw PactMatcherError('`example` cannot be a function.');
+    }
+
+    return {'pact:matcher:type': 'type', 'value': example};
+  }
+
+  /// Matches that a list of elements are the same type.
+  ///
+  /// For example, if the [value] is [1, 2, 3] then [4, 5, 3] would be a valid
+  /// match while ["a", "b", "c"] would not be.
+  ///
+  /// Optionally, set [min] and/or [max] to specify the boundary of the array.
+  static Map EachLike(dynamic example, {int min = 1, int? max}) {
+    if (min < 1) {
+      throw PactMatcherError('`min` must be greater than zero.');
+    }
+
+    if (max != null && min > max) {
+      throw PactMatcherError('`min` cannot be greater than `max`');
+    }
+
+    return {
+      'pact:matcher:type': 'type',
+      'value': example,
+      'min': min,
+      'max': max
+    };
+  }
+
+  /// Matches a "Integer" (int) value, for example, 1.
+  static Map IntegerLike(int example) {
+    return {
+      'pact:matcher:type': 'integer',
+      'value': example,
+    };
+  }
+
+  /// Matches a "Decimal" (double) value, for example, 0.84.
+  static Map DecimalLike(double example) {
+    return {
+      'pact:matcher:type': 'decimal',
+      'value': example,
+    };
+  }
+
+  /// Matches a null value
+  static Map Null() {
+    return {
+      'pact:matcher:type': 'null',
+    };
+  }
+
+  /// Matches that [value] is contained within the value being tested.
+  ///
+  /// For example, "Betsy" appears in the value "Betsy is an alligator".
+  static Map Includes(dynamic value) {
+    if (value is Function) {
+      throw PactMatcherError('`value` cannot be a function.');
+    }
+
+    return {'pact:matcher:type': 'include', 'value': value};
+  }
+}

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -13,7 +13,7 @@ class PactMatchers {
 
     final isExampleValid = RegExp(regex).hasMatch(example);
     if (!isExampleValid) {
-      throw StateError('`example` was not matched by the regex passed.');
+      throw PactMatcherError('`example` was not matched by the regex passed.');
     }
 
     return {'pact:matcher:type': 'regex', 'regex': regex, 'value': example};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,3 @@ dev_dependencies:
   http: ^0.13.3
   pedantic: ^1.10.0
   test: ^1.17.10
-
-transformers:
-  - test/pub_serve:
-      $include: test/**_test{.*,}.dart

--- a/test/integration/matchers_test.dart
+++ b/test/integration/matchers_test.dart
@@ -1,0 +1,507 @@
+import 'dart:convert';
+
+import 'package:pact_dart/src/matchers.dart';
+import 'package:test/test.dart';
+import 'package:pact_dart/pact_dart.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  late PactMockService pact;
+
+  setUp(() {
+    pact = PactMockService('test-ffi-consumer', 'test-ffi-provider');
+  });
+
+  tearDown(() {
+    pact.reset();
+  });
+
+  group('Matchers', () {
+    group('EqualTo', () {
+      test('should match when equal values is passed in request body',
+          () async {
+        final requestBody = {
+          'alligator': {
+            'name': PactMatchers.EqualTo('Betsy'),
+            'isHungry': PactMatchers.EqualTo(true)
+          }
+        };
+
+        pact
+            .newInteraction('create an alligator')
+            .uponReceiving('a request to create an alligator')
+            .withRequest('POST', '/alligator', body: requestBody)
+            .willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligator');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligator': {'name': 'Betsy', 'isHungry': true}
+            }));
+
+        expect(res.statusCode, equals(201));
+      });
+
+      test(
+          'should not match when equal values is not passed in the request body',
+          () async {
+        final requestBody = {
+          'alligator': {
+            'name': PactMatchers.EqualTo('Betsy'),
+            'isHungry': PactMatchers.EqualTo(true)
+          }
+        };
+
+        pact
+            .newInteraction('create an alligator')
+            .uponReceiving('a request to create an alligator')
+            .withRequest('POST', '/alligator', body: requestBody)
+            .willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligator');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligator': {'name': 'Graham', 'isHungry': false}
+            }));
+
+        expect(res.statusCode, isNot(201));
+      });
+    });
+
+    group('Term', () {
+      test('should match when valid regex match is passed in request body',
+          () async {
+        final requestBody = {
+          'contactEmail': PactMatchers.Term(
+              r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$',
+              'betsy@example.com')
+        };
+
+        pact
+            .newInteraction('update alligator contact email')
+            .uponReceiving('a request to update the alligators contact email')
+            .withRequest('PUT', '/alligator/1', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligator/1');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'contactEmail': 'betsylovers@example.com'}));
+
+        expect(res.statusCode, equals(204));
+      });
+
+      test(
+          'should not match when invalid regex match is passed in request body',
+          () async {
+        final requestBody = {
+          'contactEmail': PactMatchers.Term(
+              r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$',
+              'betsy@example.com')
+        };
+
+        pact
+            .newInteraction('update alligator contact email')
+            .uponReceiving('a request to update the alligators contact email')
+            .withRequest('PUT', '/alligator/1', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligator/1');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'contactEmail': '555-555-5555'}));
+
+        expect(res.statusCode, isNot(204));
+      });
+    });
+
+    group('SomethingLike', () {
+      test('should match when same types are used in the request body',
+          () async {
+        final requestBody = {
+          'alligator': {
+            'name': PactMatchers.SomethingLike('Betsy'),
+            'isHungry': PactMatchers.SomethingLike(true)
+          }
+        };
+
+        pact
+            .newInteraction('create an alligator')
+            .uponReceiving('a request to create an alligator')
+            .withRequest('POST', '/alligator', body: requestBody)
+            .willRespondWith(201);
+
+        pact
+            .newInteraction('create an alligator')
+            .uponReceiving('a request to create an alligator named betsy')
+            .withRequest('POST', '/alligator', body: {
+          'alligator': {
+            'name': PactMatchers.SomethingLike('Betsy'),
+            'isHungry': PactMatchers.SomethingLike(true)
+          }
+        }).willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligator');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligator': {'name': 'Graham', 'isHungry': false}
+            }));
+
+        expect(res.statusCode, equals(201),
+            reason: 'Mock server failed to match SomethingLike matchers');
+      });
+
+      test('should not match if a different type is in the request body',
+          () async {
+        final pact = PactMockService('test-ffi-consumer', 'test-ffi-provider');
+
+        final requestBody = {
+          'alligator': {
+            'name': PactMatchers.SomethingLike('Betsy'),
+            'isHungry': PactMatchers.SomethingLike(true)
+          }
+        };
+
+        pact
+            .newInteraction('create an alligator')
+            .uponReceiving('a request to create an alligator')
+            .withRequest('GET', '/alligator', body: requestBody)
+            .willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligator');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligator': {'name': 123, 'isHungry': 'false'}
+            }));
+
+        expect(res.statusCode, isNot(201));
+      });
+    });
+
+    group('EachLike', () {
+      test(
+          'should match when the same array element type is passed in the request body',
+          () async {
+        final requestBody = {
+          'alligators': PactMatchers.EachLike([
+            {
+              'name': PactMatchers.SomethingLike('Betsy'),
+              'isHungry': PactMatchers.SomethingLike(true)
+            }
+          ])
+        };
+
+        pact
+            .newInteraction('create alligators')
+            .uponReceiving('a request to create alligators')
+            .withRequest('POST', '/alligators', body: requestBody)
+            .willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligators': [
+                {'name': 'Graham', 'isHungry': false}
+              ]
+            }));
+
+        expect(res.statusCode, equals(201));
+      });
+
+      test(
+          'should match if the min number of elements is passed in the request body',
+          () async {
+        final requestBody = {
+          'alligators': PactMatchers.EachLike([
+            {
+              'name': PactMatchers.SomethingLike('Betsy'),
+              'isHungry': PactMatchers.SomethingLike(true)
+            }
+          ], min: 2)
+        };
+
+        pact
+            .newInteraction('create alligators')
+            .uponReceiving('a request to create alligators')
+            .withRequest('POST', '/alligators', body: requestBody)
+            .willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligators': [
+                {'name': 'Betsy', 'isHungry': true},
+                {'name': 'Graham', 'isHungry': false}
+              ]
+            }));
+
+        expect(res.statusCode, equals(201));
+      });
+
+      test(
+          'should not match if min number of array elements is not passed in the request body',
+          () async {
+        final requestBody = {
+          'alligators': PactMatchers.EachLike([
+            {
+              'name': PactMatchers.SomethingLike('Betsy'),
+              'isHungry': PactMatchers.SomethingLike(true)
+            }
+          ], min: 2)
+        };
+
+        pact
+            .newInteraction('create alligators')
+            .uponReceiving('a request to create alligators')
+            .withRequest('POST', '/alligators', body: requestBody)
+            .willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligators': [
+                {'name': 'Betsy', 'isHungry': true},
+              ]
+            }));
+
+        expect(res.statusCode, isNot(201));
+      });
+      test(
+          'should not match if max number of array elements is exceeded in request body',
+          () async {
+        final requestBody = {
+          'alligators': PactMatchers.EachLike([
+            {
+              'name': PactMatchers.SomethingLike('Betsy'),
+              'isHungry': PactMatchers.SomethingLike(true)
+            }
+          ], min: 1, max: 1)
+        };
+
+        pact
+            .newInteraction('create alligators')
+            .uponReceiving('a request to create alligators')
+            .withRequest('POST', '/alligators', body: requestBody)
+            .willRespondWith(201);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators');
+        final res = await http.post(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'alligators': [
+                {'name': 'Betsy', 'isHungry': true},
+                {'name': 'Graham', 'isHungry': false},
+              ]
+            }));
+
+        expect(res.statusCode, isNot(201));
+      });
+    });
+
+    group('IntegerLike', () {
+      test('should match when integer is passed in request body', () async {
+        final requestBody = {'numberOfTeeth': PactMatchers.IntegerLike(80)};
+
+        pact
+            .newInteraction('update alligator teeth count')
+            .uponReceiving('a request to update betsy\'s number of teeth')
+            .withRequest('PUT', '/alligators/1/teeth', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/teeth');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'numberOfTeeth': 80}));
+
+        expect(res.statusCode, equals(204));
+      });
+
+      test('should not match when integer is not passed in request body',
+          () async {
+        final requestBody = {'numberOfTeeth': PactMatchers.IntegerLike(80)};
+
+        pact
+            .newInteraction('update alligator teeth count')
+            .uponReceiving('a request to update betsy\'s number of teeth')
+            .withRequest('PUT', '/alligators/1/teeth', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/teeth');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'numberOfTeeth': 80.1}));
+
+        expect(res.statusCode, isNot(204));
+      });
+    });
+
+    group('DecimalLike', () {
+      test('should match when decimal is passed in request body', () async {
+        final requestBody = {
+          'numberOfAccidents': PactMatchers.DecimalLike(7.5)
+        };
+
+        pact
+            .newInteraction('update alligator accident count')
+            .uponReceiving('a request to update betsy\'s accident count')
+            .withRequest('PUT', '/alligators/1/accidents', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/accidents');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'numberOfAccidents': 20.5}));
+
+        expect(res.statusCode, equals(204));
+      });
+
+      test('should not match when decimal is not passed in request body',
+          () async {
+        final requestBody = {
+          'numberOfAccidents': PactMatchers.DecimalLike(7.5)
+        };
+
+        pact
+            .newInteraction('update alligator accident count')
+            .uponReceiving('a request to update betsy\'s accident count')
+            .withRequest('PUT', '/alligators/1/accidents', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/accidents');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'numberOfAccidents': 20}));
+
+        expect(res.statusCode, isNot(204));
+      });
+    });
+
+    group('Null', () {
+      test('should match when null is passed in request body', () async {
+        final requestBody = {'favouriteFood': PactMatchers.Null()};
+
+        pact
+            .newInteraction('update alligator favourite food')
+            .uponReceiving('a request to update betsy\'s favourite food')
+            .withRequest('PUT', '/alligators/1/metadata', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/metadata');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'favouriteFood': null}));
+
+        expect(res.statusCode, equals(204));
+      });
+
+      test('should not match when null is not passed in request body',
+          () async {
+        final requestBody = {'favouriteFood': PactMatchers.Null()};
+
+        pact
+            .newInteraction('update alligator favourite food')
+            .uponReceiving('a request to update betsy\'s favourite food')
+            .withRequest('PUT', '/alligators/1/metadata', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/metadata');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'favouriteFood': ['Kibble']
+            }));
+
+        expect(res.statusCode, isNot(204));
+      });
+    });
+
+    group('Includes', () {
+      test('should match when certain text is passed in request body',
+          () async {
+        final requestBody = {
+          'favouriteFood': PactMatchers.Includes('Pineapple')
+        };
+
+        pact
+            .newInteraction('update alligator favourite food')
+            .uponReceiving('a request to update betsy\'s favourite food')
+            .withRequest('PUT', '/alligators/1/metadata', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/metadata');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'favouriteFood': ['Kibble', 'Humans', 'Pineapple']
+            }));
+
+        expect(res.statusCode, equals(204));
+      });
+
+      test('should not match when certain text is not passed in request body',
+          () async {
+        final requestBody = {
+          'favouriteFood': PactMatchers.Includes('Pineapple')
+        };
+
+        pact
+            .newInteraction('update alligator favourite food')
+            .uponReceiving('a request to update betsy\'s favourite food')
+            .withRequest('PUT', '/alligators/1/metadata', body: requestBody)
+            .willRespondWith(204);
+
+        pact.run(secure: false);
+
+        final uri = Uri.parse('http://localhost:1235/alligators/1/metadata');
+        final res = await http.put(uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'favouriteFood': ['Kibble', 'Humans']
+            }));
+
+        expect(res.statusCode, isNot(204));
+      });
+    });
+  });
+}

--- a/test/unit/matchers_test.dart
+++ b/test/unit/matchers_test.dart
@@ -1,0 +1,81 @@
+import 'package:pact_dart/src/errors.dart';
+import 'package:pact_dart/src/matchers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Term', () {
+    test(
+        'should conform to pact specification if `example` is matched by `regex`',
+        () {
+      final regex = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$';
+      final value = 'betsy@example.com';
+      final matcher = PactMatchers.Term(regex, value);
+
+      expect(matcher['pact:matcher:type'], equals('regex'));
+      expect(matcher['regex'], equals(regex));
+      expect(matcher['value'], equals(value));
+    });
+
+    test('should throw error is `regex` or `example` is empty', () {
+      expect(() => PactMatchers.Term('', ''), throwsA(isA<PactMatcherError>()));
+      expect(() => PactMatchers.Term('', 'test'),
+          throwsA(isA<PactMatcherError>()));
+      expect(() => PactMatchers.Term(r'abc', ''),
+          throwsA(isA<PactMatcherError>()));
+    });
+
+    test('should throw error if `example` is not matched by `regex', () {
+      expect(
+          () => PactMatchers.Term(
+              r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$',
+              '555-555-5555'),
+          throwsA(isA<PactMatcherError>()));
+    });
+  });
+
+  group('SomethingLike', () {
+    test('should conform to pact specification if `example` is passed', () {
+      final example = 'test';
+      final matcher = PactMatchers.SomethingLike(example);
+
+      expect(matcher['pact:matcher:type'], equals('type'));
+      expect(matcher['value'], equals(example));
+    });
+
+    test('should throw error is `example` is func', () {
+      expect(() => PactMatchers.SomethingLike(() => 'test'),
+          throwsA(isA<PactMatcherError>()));
+    });
+  });
+
+  group('EachLike', () {
+    test('should conform to pact specification if paramters are valid', () {
+      final example = ['test'];
+      final min = 1;
+      final max = 5;
+      final matcher = PactMatchers.EachLike(example, min: min, max: max);
+
+      expect(matcher['pact:matcher:type'], equals('type'));
+      expect(matcher['value'], equals(example));
+      expect(matcher['min'], equals(min));
+      expect(matcher['max'], equals(max));
+    });
+
+    test('should throw error is `min` lower than one', () {
+      expect(() => PactMatchers.EachLike(['test'], min: 0),
+          throwsA(isA<PactMatcherError>()));
+    });
+
+    test('should throw error is `min` is greater than `max', () {
+      expect(() => PactMatchers.EachLike(['test'], min: 10, max: 2),
+          throwsA(isA<PactMatcherError>()));
+    });
+  });
+
+  group('EachLike', () {
+    test('should throw error is `value` is func', () {
+      expect(() => PactMatchers.Includes(() => 'test'),
+          throwsA(isA<PactMatcherError>()));
+    });
+  });
+}


### PR DESCRIPTION
This PR implements a DSL for creating matchers based on the Pact Specification v3.0.0. Implemented methods:

* EqualTo
* SomethingLike
* IntegerLike
* DecimalLike
* Includes
* Null
* Term
* EachLike