### PR TITLE
Improve Shell Output When An Error Occurs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           PACT_DART_LIB_DOWNLOAD_PATH: .
       - name: Format coverage
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
+        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --report-on=lib
       - uses: codecov/codecov-action@v2
         with:
           files: ./coverage.lcov

--- a/lib/src/bindings/bindings.dart
+++ b/lib/src/bindings/bindings.dart
@@ -49,6 +49,13 @@ class PactFFIBindings {
 
   late int Function(int mock_server_port) pactffi_mock_server_matched;
 
+  /// External interface to get all the mismatches from a mock server. The port number of the
+  /// mock server is passed in, and a pointer to a C string with the mismatches in JSON
+  /// format is returned.
+  ///
+  /// https://docs.rs/pact_ffi/0.3.3/pact_ffi/mock_server/fn.pactffi_mock_server_mismatches.html
+  /// https://docs.rs/pact_ffi/0.3.3/src/pact_ffi/mock_server/mod.rs.html#391-414
+  ///
   late Pointer<Utf8> Function(int mock_server_port)
       pactffi_mock_server_mismatches;
 
@@ -59,6 +66,13 @@ class PactFFIBindings {
       int index, Pointer<Utf8> value) pactffi_with_query_parameter;
 
   late int Function(int mock_server_port) pactffi_cleanup_mock_server;
+
+  /// Get a description of a mismatch.
+  ///
+  /// https://docs.rs/pact_ffi/0.3.3/pact_ffi/fn.pactffi_mismatch_description.html
+  /// https://docs.rs/pact_ffi/0.3.3/src/pact_ffi/lib.rs.html#265-274
+  late Pointer<Utf8> Function(Pointer<Utf8> mismatches)
+      pactffi_mismatch_description;
 
   PactFFIBindings() {
     pactffi = openLibrary();
@@ -146,6 +160,11 @@ class PactFFIBindings {
     pactffi_cleanup_mock_server = pactffi
         .lookup<NativeFunction<pactffi_cleanup_mock_server_native>>(
             'pactffi_cleanup_mock_server')
+        .asFunction();
+
+    pactffi_mismatch_description = pactffi
+        .lookup<NativeFunction<pactffi_mismatch_description_native>>(
+            'pactffi_mismatch_description')
         .asFunction();
   }
 }

--- a/lib/src/bindings/signatures.dart
+++ b/lib/src/bindings/signatures.dart
@@ -74,6 +74,12 @@ typedef pactffi_mock_server_logs_native = Pointer<Utf8> Function(
 typedef pactffi_mock_server_matched_native = Int8 Function(
     Int32 mock_server_port);
 
+/// External interface to get all the mismatches from a mock server. The port number of the
+/// mock server is passed in, and a pointer to a C string with the mismatches in JSON
+/// format is returned.
+///
+/// https://docs.rs/pact_ffi/0.3.3/pact_ffi/mock_server/fn.pactffi_mock_server_mismatches.html
+/// https://docs.rs/pact_ffi/0.3.3/src/pact_ffi/mock_server/mod.rs.html#391-414
 typedef pactffi_mock_server_mismatches_native = Pointer<Utf8> Function(
     Int32 mock_server_port);
 
@@ -147,3 +153,10 @@ typedef pactffi_write_message_pact_file_native = Int32 Function(
 
 typedef pactffi_write_pact_file_native = Int32 Function(
     Int32 mock_server_port, Pointer<Utf8> directory, Int8 overwrite);
+
+/// Get a description of a mismatch.
+///
+/// https://docs.rs/pact_ffi/0.3.3/pact_ffi/fn.pactffi_mismatch_description.html
+/// https://docs.rs/pact_ffi/0.3.3/src/pact_ffi/lib.rs.html#265-274
+typedef pactffi_mismatch_description_native = Pointer<Utf8> Function(
+    Pointer<Utf8> mismatch);

--- a/lib/src/pact_mock_service.dart
+++ b/lib/src/pact_mock_service.dart
@@ -76,6 +76,8 @@ class PactMockService {
     }
   }
 
+  void onPactMismatches() {}
+
   /// Verifies the interactions were matched and writes the JSON contract
   void writePactFile({String directory = 'contracts', bool overwrite = false}) {
     final hasMatchedInteractions = this.hasMatchedInteractions();
@@ -83,8 +85,7 @@ class PactMockService {
     if (!hasMatchedInteractions) {
       final mismatches =
           bindings.pactffi_mock_server_mismatches(port).toDartString();
-
-      throw PactMismatchError(mismatches);
+      throw PactMatchFailure(mismatches);
     }
 
     final result = bindings.pactffi_write_pact_file(

--- a/lib/src/utils/content_type.dart
+++ b/lib/src/utils/content_type.dart
@@ -1,0 +1,8 @@
+String getContentType<T>(content) {
+  switch (T) {
+    case Map<String, dynamic>:
+      return 'application/json';
+    default:
+      return 'text/plain';
+  }
+}

--- a/lib/src/utils/content_type.dart
+++ b/lib/src/utils/content_type.dart
@@ -1,8 +1,7 @@
-String getContentType<T>(content) {
-  switch (T) {
-    case Map<String, dynamic>:
-      return 'application/json';
-    default:
-      return 'text/plain';
+String getContentType(content) {
+  if (content is Map) {
+    return 'application/json';
   }
+
+  return 'text/plain';
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -352,4 +352,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.5.0
 homepage: https://github.com/matthewshirley/pact_dart
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   ffi: ^1.1.2


### PR DESCRIPTION
This merge request improves the output for when an error occurs so that developers aren't overwhelmed by the 

### Example
```
Pact was unable to validate one or more interaction(s):

Interaction Mismatch #1
        Reason:
                Request was not matched (GET /alligators)

        Expected:
                - Expected query parameter 'nice' but was missing
                - Expected query parameter 'hungry' but was missing

Interaction Mismatch #2
        Reason:
                Request was unexpected

        Actual:
                GET /croc

Interaction Mismatch #3
        Reason:
                Request was missing

        Expected:
                GET /alligator
```