### PR TITLE
chore(deps): Move http package to dev_dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "2.1.3"
   http:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: http
       sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 dependencies:
   ffi: ^2.0.1
   path: ^1.8.0
-  http: ^0.13.3
   logging: ^1.0.1
 
 dev_dependencies:
   test: ^1.17.10
+  http: ^0.13.3
 
 executables:
   install:


### PR DESCRIPTION
Hi @matthewshirley 

While installing `pact_dart` in my project, I can't install it, because it conflict with `http: ^1.4`. After checking the `pact_dart` 's dependencies, I think we can move `http` to `dev_depdencies`, because it's only used in [integration tests](https://github.com/matthewshirley/pact_dart/tree/main/test/integration)

I'm new to Dart, so please tell me if there is any better solution.